### PR TITLE
Add color scheme UI and theme styles

### DIFF
--- a/project-app/src/app/app.html
+++ b/project-app/src/app/app.html
@@ -1,6 +1,60 @@
-<div class="container">
-  <div class="display-4">
-    <p>{{ message() }}</p>
+<div class="color-test container py-5">
+  <h1 class="display-4 mb-5 text-charcoal">Color Scheme Test</h1>
+  <div class="row g-4 mb-5">
+    <div class="col-md-3 col-sm-6">
+      <div class="color-swatch h-100 text-center p-4 rounded-3 shadow"
+           style="background: var(--cream); border: 4px solid var(--cream);">
+        <h3>Cream</h3>
+        <code class="d-block bg-dark text-white px-2 py-1 rounded small">var(--cream)</code>
+        <small>#FAF7F0</small>
+      </div>
+    </div>
+    <div class="col-md-3 col-sm-6">
+      <div class="color-swatch h-100 text-center p-4 rounded-3 shadow"
+           style="background: var(--beige); border: 4px solid var(--beige);">
+        <h3>Beige</h3>
+        <code class="d-block bg-dark text-white px-2 py-1 rounded small">var(--beige)</code>
+        <small>#D8D2C2</small>
+      </div>
+    </div>
+    <div class="col-md-3 col-sm-6">
+      <div class="color-swatch h-100 text-center p-4 rounded-3 shadow bg-rust"
+           style="border: 4px solid var(--rust); color: white;">
+        <h3>Rust</h3>
+        <code class="d-block bg-charcoal px-2 py-1 rounded small">var(--rust)</code>
+        <small>#B17457</small>
+      </div>
+    </div>
+    <div class="col-md-3 col-sm-6">
+      <div class="color-swatch h-100 text-center p-4 rounded-3 shadow"
+           style="background: var(--charcoal); border: 4px solid var(--charcoal); color: white;">
+        <h3>Charcoal</h3>
+        <code class="d-block bg-cream px-2 py-1 rounded small">var(--charcoal)</code>
+        <small>#4A4947</small>
+      </div>
+    </div>
+  </div>
+
+  <!-- Bootstrap Component Tests -->
+  <div class="row g-4">
+    <div class="col-md-4">
+      <button class="btn btn-rust btn-lg w-100 mb-3">Primary Rust Button</button>
+      <button class="btn btn-outline-rust btn-lg w-100">Outline Rust</button>
+    </div>
+    <div class="col-md-4">
+      <div class="card border-0 shadow-lg h-100 p-4 text-rust">
+        <h4>Card with Rust Text</h4>
+        <p>Secondary: <span class="text-secondary">var(--beige)</span></p>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="bg-gradient rounded-4 p-4 text-white h-100 d-flex align-items-center justify-content-center">
+        <div class="text-center">
+          <i class="bi bi-check-circle-fill display-4 mb-3"></i>
+          <h3>Gradient Test</h3>
+          <small>cream → beige</small>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
-

--- a/project-app/src/app/app.ts
+++ b/project-app/src/app/app.ts
@@ -1,4 +1,4 @@
-import {Component, signal} from '@angular/core';
+import {Component} from '@angular/core';
 
 @Component({
   selector: 'app-root',
@@ -7,6 +7,4 @@ import {Component, signal} from '@angular/core';
   styleUrl: './app.scss'
 })
 export class App {
-
-  protected readonly message = signal("Todo rust project");
 }

--- a/project-app/src/index.html
+++ b/project-app/src/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
-<body>
+<body class="todo-app">
   <app-root></app-root>
 </body>
 </html>

--- a/project-app/src/styles.scss
+++ b/project-app/src/styles.scss
@@ -1,1 +1,39 @@
-/* You can add global styles to this file, and also import other style files */
+:root {
+  --cream: #FAF7F0;
+  --beige: #D8D2C2;
+  --rust: #B17457;
+  --charcoal: #4A4947;
+}
+
+$primary: var(--rust);
+$secondary: var(--beige);
+$success: #8CB369;
+$info: var(--cream);
+$warning: var(--rust);
+$danger: #D9534F;
+$light: var(--cream);
+$dark: var(--charcoal);
+
+$theme-colors: (
+  "primary": $primary,
+  "secondary": $secondary,
+  "success": $success,
+  "info": $info,
+  "warning": $warning,
+  "danger": $danger,
+  "light": $light,
+  "dark": $dark
+);
+
+$body-bg: var(--cream);
+$body-color: var(--charcoal);
+
+.text-rust { color: var(--rust) !important; }
+.bg-rust { background-color: var(--rust) !important; }
+.border-rust { border-color: var(--rust) !important; }
+
+
+.todo-app {
+  min-height: 100vh;
+  background: linear-gradient(135deg, var(--cream) 0%, var(--beige) 100%);
+}


### PR DESCRIPTION
Introduce a visual color-scheme test layout and theme variables. Replaced the simple message view with a set of color swatches and Bootstrap component examples in app.html. Added CSS custom properties and SCSS theme variables plus utility classes (text/bg/border-rust) and a page background gradient in styles.scss. Applied a .todo-app class to the body in index.html to enable the new background, and removed the unused signal import and message signal from app.ts.

<img width="1710" height="982" alt="Screenshot 2026-02-14 at 15 39 11" src="https://github.com/user-attachments/assets/df7fbaed-ef30-4829-b97c-6a10dfda3b5e" />
